### PR TITLE
Update to v0.0.20250416202228

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,13 @@
+@echo on
+
+python build/gen.py
+if errorlevel 1 exit 1
+
+ninja -C out
+if errorlevel 1 exit 1
+
+mkdir %PREFIX%\bin
+
+echo "Copying Binaries"
+copy out\gn.exe %PREFIX%\bin\gn.exe
+if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 @echo on
 
-python build/gen.py
+python build/gen.py --no-static-libstdc++ --allow-warnings
 if errorlevel 1 exit 1
 
 ninja -C out

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-python build/gen.py
+python build/gen.py --no-static-libstdc++ --allow-warnings
 ninja -C out
 mkdir -p $PREFIX/bin
 cp out/gn $PREFIX/bin/gn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # notation.
 
 {% set name = "gn" %}
-{% set version = "0.0.20200909083119" %}
+{% set version = "0.0.20250416202228" %}
 
 package:
   name: {{ name|lower }}
@@ -12,28 +12,25 @@ package:
 source:
   # We have to use git as the source as the provided tarballs are not stable.
   git_url: https://gn.googlesource.com/gn
-  git_rev: e002e68a48d1c82648eadde2f6aafa20d08c36f2
-  patches:
-    - add-lrt.patch
+  git_rev: 10a27145cd0770b78745ff536e343bf12c70f6c3
+  # patches:
+  #   - add-lrt.patch
 
 build:
-  number: 2
-  skip: true  # [win]
+  number: 0
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python
     - ninja
-    - patch
-    - git
-  host:
-  run:
 
 test:
   commands:
-    - test -f $PREFIX/bin/gn
+    - test -f $PREFIX/bin/gn                     # [unix]
+    - if not exist %PREFIX%\\bin\\gn.exe exit 1  # [win]
 
 about:
   home: https://gn.googlesource.com/gn/
@@ -41,6 +38,10 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: 'GN is a meta-build system that generates build files for Ninja.'
+  description: |
+    GN is currently used as the build system for Chromium, Fuchsia, and related projects.
+  doc_url: https://gn.googlesource.com/gn/+/refs/heads/main/README.md
+  dev_url: https://gn.googlesource.com/gn/+/refs/heads/main
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
gn 0.0.20250416202228

**Destination channel:** defaults

### Links

- [PKG-9710](https://anaconda.atlassian.net/browse/PKG-9710)
- [Upstream repository](https://gn.googlesource.com/gn/+/10a27145cd0770b78745ff536e343bf12c70f6c3)

### Explanation of changes:

- Building modern version to lessen built time of QtWebEngine


[PKG-9710]: https://anaconda.atlassian.net/browse/PKG-9710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ